### PR TITLE
Update mkdocs, remove Python script from Soar manual PDF version, add mkdocs glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+output
+
+# Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# -----------------------------------------------------------------------------
+# Node, TypeScript, Python
+# -----------------------------------------------------------------------------
+
+# Dependencies
+node_modules
+__pycache__
+venv
+.venv
+
+# Build files
+build
+site
+
+# Distribution files
+dist
+mkdocs_material.egg-info
+
+# Caches and logs
+*.cpuprofile
+*.log
+*.tsbuildinfo
+.cache
+.eslintcache
+__pycache__
+
+# Examples
+example
+example.zip
+
+# -----------------------------------------------------------------------------
+# General
+# -----------------------------------------------------------------------------
+
+# Never ignore .gitkeep files
+!**/.gitkeep
+
+# macOS internals
+.DS_Store
+
+# Temporary files
+TODO
+tmp
+
+# IDEs & Editors
+.idea
+*~

--- a/docs/soar_manual/build.sh
+++ b/docs/soar_manual/build.sh
@@ -1,3 +1,5 @@
+# Run this file from the root directory of this repository, otherwise
+# the template.tex file path does not match.
 mkdir output
 
 pandoc \
@@ -17,5 +19,5 @@ pandoc \
     docs/soar_manual/07_EpisodicMemory.md \
     docs/soar_manual/08_SpatialVisualSystem.md \
     docs/soar_manual/09_SoarUserInterface.md \
-    docs/reference/cli/* \
+    docs/reference/cli/*.md \
     -o output/SoarManual.pdf

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,0 +1,6 @@
+<!-- <!-- markdownlint-disable-file MD041-->
+
+*[SGIO]: Soar General Input/Output Interface
+*[Tcl]: Tool Command Language
+*[DARPA]: Defense Advanced Research Projects Agency
+*[SML]: Soar Markup Language

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,4 +1,4 @@
-<!-- <!-- markdownlint-disable-file MD041-->
+<!-- markdownlint-disable-file MD041-->
 
 *[SGIO]: Soar General Input/Output Interface
 *[Tcl]: Tool Command Language

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,12 +2,16 @@ site_name: Soar documentation
 repo_url: http://github.com/SoarGroup/Documentation
 repo_name: SoarGroup/Documentation
 copyright: SoarGroup &copy;
+edit_uri: edit/main/docs/
 
 theme:
   name: material
   locale: en
   features:
     - content.code.copy
+    - content.action.view
+    - content.action.edit
+    - content.tooltips
     - navigation.tabs
     - navigation.footer
     - navigation.top
@@ -15,16 +19,22 @@ theme:
     - navigation.expand
     - header.autohide
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode
-  logo: Images/soar.png
-  custom_dir: overrides
+      logo: Images/soar.png
+      custom_dir: overrides
 
 extra_javascript:
   - javascripts/mathjax.js
@@ -41,50 +51,57 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - abbr
+  - attr_list
+  - pymdownx.snippets:
+      auto_append:
+        - includes/abbreviations.md
   - pymdownx.superfences
   - attr_list
   - md_in_html
   - pymdownx.arithmatex:
       generic: true
 
+watch:
+  - includes
+
 nav:
   - Soar:
       - index.md
       - Research:
-          - Publications: "soar/Publications.md"
-          - Research Groups: "soar/ResearchGroups.md"
-          - Academic Institutions: "soar/OtherAcademicInstitutions.md"
-          - Commercial Soar Organizations: "soar/CommercialSoarOrganizations.md"
+          - Publications: soar/Publications.md
+          - Research Groups: soar/ResearchGroups.md
+          - Academic Institutions: soar/OtherAcademicInstitutions.md
+          - Commercial Soar Organizations: soar/CommercialSoarOrganizations.md
   - Soar Manual:
       - soar_manual/index.md
-      - Introduction:  "soar_manual/01_Introduction.md"
-      - The Soar Architecture: "soar_manual/02_TheSoarArchitecture.md"
-      - Syntax of Soar Programs: "soar_manual/03_SyntaxOfSoarPrograms.md"
-      - Procedural Knowledge Learning: "soar_manual/04_ProceduralKnowledgeLearning.md"
-      - Reinforcement Learning: "soar_manual/05_ReinforcementLearning.md"
-      - Semantic Memory: "soar_manual/06_SemanticMemory.md"
-      - Episodic Memory: "soar_manual/07_EpisodicMemory.md"
-      - Spatial Visual System: "soar_manual/08_SpatialVisualSystem.md"
-      - Soar User Interface: "soar_manual/09_SoarUserInterface.md"
-      - Blocksworld: "soar_manual/blocksworld.md"
+      - Introduction: soar_manual/01_Introduction.md
+      - The Soar Architecture: soar_manual/02_TheSoarArchitecture.md
+      - Syntax of Soar Programs: soar_manual/03_SyntaxOfSoarPrograms.md
+      - Procedural Knowledge Learning: soar_manual/04_ProceduralKnowledgeLearning.md
+      - Reinforcement Learning: soar_manual/05_ReinforcementLearning.md
+      - Semantic Memory: soar_manual/06_SemanticMemory.md
+      - Episodic Memory: soar_manual/07_EpisodicMemory.md
+      - Spatial Visual System: soar_manual/08_SpatialVisualSystem.md
+      - Soar User Interface: soar_manual/09_SoarUserInterface.md
+      - Blocksworld: soar_manual/blocksworld.md
   - Explanations:
       - explanations/index.md
-      - Basic Kernel Terminology: "explanations/BasicKernelTerminology.md"
-      - Design Dogma: "explanations/DesignDogma.md"
-      - Threads in SML: "explanations/ThreadsInSML.md"
-      - Timers: "explanations/Timers.md"
-      - Waterfall: "explanations/Waterfall.md"
+      - Basic Kernel Terminology: explanations/BasicKernelTerminology.md
+      - Design Dogma: explanations/DesignDogma.md
+      - Threads in SML: explanations/ThreadsInSML.md
+      - Timers: explanations/Timers.md
+      - Waterfall: explanations/Waterfall.md
   - Tutorials:
       - tutorials/index.md
       - Java Soar Debugger Intro: tutorials/IntroSoarDebugger.md
       - Soar Markup Language: tutorials/SMLQuickStartGuide.md
       - Official Soar Tutorials:
-          - "tutorials/soar_tutorial/index.md"
-          - Tank and Eaters Configuration: "tutorials/soar_tutorial/TankEatersConfigFile.md"
+          - tutorials/soar_tutorial/index.md
+          - Tank and Eaters Configuration: tutorials/soar_tutorial/TankEatersConfigFile.md
   - HowTo Guides:
       - how_to/index.md
-      - Building Soar and ROS1: "how_to/BuildingSoarRos.md"
+      - Building Soar and ROS1: how_to/BuildingSoarRos.md
       - CLI Parsing Code: how_to/CLIParsingCode.md
       - How to compile SML Clients: how_to/HowToCompileSmlClients.md
       - IO and Reward Links: how_to/IOAndRewardLinks.md
@@ -93,47 +110,45 @@ nav:
       - Soar Technical FAQ: how_to/SoarTechnicalFAQ.md
   - Reference:
       - reference/index.md
-      - Command Line Interface: 
-        - "reference/cli/index.md"
-        - alias: "reference/cli/cmd_alias.md"
-        - trace: "reference/cli/cmd_trace.md"
-        - help: "reference/cli/cmd_help.md"
-        - sp: "reference/cli/cmd_sp.md"
-        - load: "reference/cli/cmd_load.md"
-        - gp: "reference/cli/cmd_gp.md"
-        - wm: "reference/cli/cmd_wm.md"
-        - rl: "reference/cli/cmd_rl.md"
-        - default_wme_depth: "reference/cli/cmd_default_wme_depth.md"
-        - stop_soar: "reference/cli/cmd_stop_soar.md"
-        - alias: "reference/cli/cmd_alias.md"
-        - echo: "reference/cli/cmd_echo.md"
-        - command_to_file: "reference/cli/cmd_command_to_file.md"
-        - unalias: "reference/cli/cmd_unalias.md"
-        - epmem: "reference/cli/cmd_epmem.md"
-        - clog: "reference/cli/cmd_clog.md"
-        - visualize: "reference/cli/cmd_visualize.md"
-        - preference: "reference/cli/cmd_preferences.md"
-        - excise: "reference/cli/cmd_excise.md"
-        - production: "reference/cli/cmd_production.md"
-        - wma: "reference/cli/cmd_wma.md"
-        - smem: "reference/cli/cmd_smem.md"
-        - chunk: "reference/cli/cmd_chunk.md"
-        - soar: "reference/cli/cmd_soar.md"
-        - run: "reference/cli/cmd_run.md"
-        - svs: "reference/cli/cmd_svs.md"
-        - explain: "reference/cli/cmd_explain.md"
-        - init_soar: "reference/cli/cmd_init_soar.md"
-        - decide: "reference/cli/cmd_decide.md"
-        - print: "reference/cli/cmd_print.md"
-        - debug: "reference/cli/cmd_debug.md"
-        - stats: "reference/cli/cmd_stats.md"
-        - timers: "reference/cli/cmd_timers.md"
-        - watch: "reference/cli/cmd_watch.md"
-        - save: "reference/cli/cmd_save.md"
-        - max_nil_output_cycles: "reference/cli/cmd_max_nil_output_cycles.md"
-        - file_system: "reference/cli/cmd_file_system.md"
-        - output: "reference/cli/cmd_output.md"
-  - Tag Index: "soar/tags.md"
+      - Command Line Options for Debugging and CLI: reference/CommandLineOptionsForDebuggerAndCLI.md
+      - Command Line Interface:
+          - reference/cli/index.md
+          - alias: reference/cli/cmd_alias.md
+          - chunk: reference/cli/cmd_chunk.md
+          - command_to_file: reference/cli/cmd_command_to_file.md
+          - debug: reference/cli/cmd_debug.md
+          - decide: reference/cli/cmd_decide.md
+          - default_wme_depth: reference/cli/cmd_default_wme_depth.md
+          - echo: reference/cli/cmd_echo.md
+          - epmem: reference/cli/cmd_epmem.md
+          - excise: reference/cli/cmd_excise.md
+          - explain: reference/cli/cmd_explain.md
+          - file_system: reference/cli/cmd_file_system.md
+          - gp: reference/cli/cmd_gp.md
+          - help: reference/cli/cmd_help.md
+          - init_soar: reference/cli/cmd_init_soar.md
+          - load: reference/cli/cmd_load.md
+          - max_nil_output_cycles: reference/cli/cmd_max_nil_output_cycles.md
+          - output: reference/cli/cmd_output.md
+          - preference: reference/cli/cmd_preferences.md
+          - print: reference/cli/cmd_print.md
+          - production: reference/cli/cmd_production.md
+          - rl: reference/cli/cmd_rl.md
+          - run: reference/cli/cmd_run.md
+          - save: reference/cli/cmd_save.md
+          - smem: reference/cli/cmd_smem.md
+          - soar: reference/cli/cmd_soar.md
+          - sp: reference/cli/cmd_sp.md
+          - stats: reference/cli/cmd_stats.md
+          - stop_soar: reference/cli/cmd_stop_soar.md
+          - svs: reference/cli/cmd_svs.md
+          - timers: reference/cli/cmd_timers.md
+          - trace: reference/cli/cmd_trace.md
+          - visualize: reference/cli/cmd_visualize.md
+          - watch: reference/cli/cmd_watch.md
+          - wm: reference/cli/cmd_wm.md
+          - wma: reference/cli/cmd_wma.md
+  - Tag Index: soar/tags.md
 
 plugins:
   - search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs-img2figv2-plugin==0.0.2
-mkdocs-material==9.2.8
-mkdocs-material-extensions==1.1.1
+mkdocs-material==9.*
+mkdocs-material-extensions==1.*
 python-markdown-math==0.8


### PR DESCRIPTION
- Updated mkdocs Material to 9.5.* to use automatic light/dark toggle
- Use abbreviations function (global glossary) of mkdocs since it does not interfere with the Markdown used to generate PDFs. This is just a quality of life addition. 
- Fix a bug where the a Python script is included in the Soar manual (PDF Version)